### PR TITLE
:rotating_light: Suppress warnings about esbuild-wasm for a while

### DIFF
--- a/src/esbuild-wasm/common.ts
+++ b/src/esbuild-wasm/common.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file
 /** esbuild-wasm@0.12.25
  *
  * MIT License

--- a/src/esbuild-wasm/mod.ts
+++ b/src/esbuild-wasm/mod.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file
 /** esbuild-wasm@0.12.25
  *
  * MIT License

--- a/src/esbuild-wasm/stdio_protocol.ts
+++ b/src/esbuild-wasm/stdio_protocol.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file
 /** esbuild-wasm@0.12.25
  *
  * MIT License

--- a/src/esbuild-wasm/types.ts
+++ b/src/esbuild-wasm/types.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file
 /** esbuild-wasm@0.12.25
  *
  * MIT License

--- a/src/esbuild.worker.js
+++ b/src/esbuild.worker.js
@@ -1,5 +1,5 @@
 // deno-fmt-ignore-file
-// // deno-lint-ignore-file\n
+// deno-lint-ignore-file
 /** esbuild-wasm@0.12.25 */
 let global={};for(let o=self;o;o=Object.getPrototypeOf(o))for(let k of Object.getOwnPropertyNames(o))if(!(k in global))Object.defineProperty(global,k,{get:()=>self[k]});
 // Copyright 2018 The Go Authors. All rights reserved.


### PR DESCRIPTION
ref [esbuild-wasmのlinter errorsを一旦無視する (@takker/ScrapJupyter)](https://scrapbox.io/takker/esbuild-wasm%E3%81%AElinter_errors%E3%82%92%E4%B8%80%E6%97%A6%E7%84%A1%E8%A6%96%E3%81%99%E3%82%8B_(@takker%2FScrapJupyter))