### PR TITLE
Import URL which doesn't have an extension

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -1,4 +1,5 @@
-import { build, httpFetch, initialize } from "./deps/esbuild-wasm.ts";
+import { build, initialize } from "./deps/esbuild-wasm.ts";
+import { httpFetch } from "./esbuild-wasm/plugin.ts";
 
 declare const WORKER_URL: string;
 declare const WASM_URL: string;

--- a/src/deps/esbuild-wasm.ts
+++ b/src/deps/esbuild-wasm.ts
@@ -1,2 +1,1 @@
 export { build, initialize } from "../esbuild-wasm/mod.ts";
-export { default as httpFetch } from "https://deno.land/x/esbuild_plugin_http_fetch@v1.0.3/index.js";

--- a/src/deps/media_types.ts
+++ b/src/deps/media_types.ts
@@ -1,0 +1,1 @@
+export { extension } from "https://deno.land/x/media_types@v2.10.2/mod.ts";

--- a/src/deps/path.ts
+++ b/src/deps/path.ts
@@ -1,0 +1,1 @@
+export { extname } from "https://deno.land/std@0.107.0/path/mod.ts";

--- a/src/esbuild-wasm/plugin.ts
+++ b/src/esbuild-wasm/plugin.ts
@@ -1,0 +1,54 @@
+import { Loader, Plugin } from "./types.ts";
+import { extname } from "../deps/path.ts";
+import { extension } from "../deps/media_types.ts";
+
+const httpFetchNamespace = "http-fetch";
+export const httpFetch: Plugin = {
+  name: httpFetchNamespace,
+  setup({ onResolve, onLoad, initialOptions }) {
+    onResolve(
+      { filter: /^https?:\/\// },
+      ({ path }) => ({
+        path,
+        namespace: httpFetchNamespace,
+      }),
+    );
+    onResolve(
+      { filter: /.*/, namespace: httpFetchNamespace },
+      ({ path, importer }) => ({
+        path: new URL(path, importer).href,
+        namespace: httpFetchNamespace,
+      }),
+    );
+
+    const loaderList = new Map<string, Loader>([
+      [".js", "js"],
+      [".mjs", "js"],
+      [".ts", "ts"],
+      [".jsx", "jsx"],
+      [".tsx", "tsx"],
+      [".css", "css"],
+      [".txt", "text"],
+      [".json", "json"],
+    ]);
+    Object.entries(initialOptions.loader ?? {}).forEach(([key, value]) =>
+      loaderList.set(key, value)
+    );
+
+    onLoad({ filter: /.*/, namespace: httpFetchNamespace }, async (args) => {
+      const res = await fetch(args.path);
+      const contentType = res.headers.get("content-type");
+      const ext = getExtension(args.path, contentType);
+      const contents = new Uint8Array(await res.arrayBuffer());
+      return { contents, loader: loaderList.get(ext) ?? "default" };
+    });
+  },
+};
+
+function getExtension(path: string, contentType: string | null) {
+  if (contentType !== null) {
+    const ext = extension(contentType);
+    if (ext !== undefined) return `.${ext}`;
+  }
+  return extname(path) || ".txt";
+}


### PR DESCRIPTION
ref [末尾が拡張子で終わらないURLもimportできるようにする (ScrapJupyter)](https://scrapbox.io/takker/%E6%9C%AB%E5%B0%BE%E3%81%8C%E6%8B%A1%E5%BC%B5%E5%AD%90%E3%81%A7%E7%B5%82%E3%82%8F%E3%82%89%E3%81%AA%E3%81%84URL%E3%82%82import%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B_(ScrapJupyter))