### PR TITLE
Fully support for source map of `app.ts`

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,8 +3,10 @@
 /// <reference lib="dom"/>
 import { getCodeFiles } from "./codeFile.ts";
 import { bundle, isAvailableExtensions } from "./bundler.ts";
-import { eventName, scrapbox } from "./deps/scrapbox.ts";
+import { eventName } from "./deps/scrapbox.ts";
+import { Scrapbox } from "./deps/scrapbox.ts";
 import { execMenu } from "./components/execMenu.ts";
+declare const scrapbox: Scrapbox;
 
 const menus = [] as ReturnType<typeof execMenu>[];
 

--- a/src/codeFile.ts
+++ b/src/codeFile.ts
@@ -1,5 +1,6 @@
-import { scrapbox } from "./deps/scrapbox.ts";
+import { Scrapbox } from "./deps/scrapbox.ts";
 import { toLc } from "./utils.ts";
+declare const scrapbox: Scrapbox;
 
 type File = {
   filename?: string;

--- a/src/deps/fs.ts
+++ b/src/deps/fs.ts
@@ -1,1 +1,1 @@
-export { ensureDir } from "https://deno.land/std@0.106.0/fs/mod.ts";
+export { ensureDir, exists } from "https://deno.land/std@0.106.0/fs/mod.ts";

--- a/src/deps/scrapbox.ts
+++ b/src/deps/scrapbox.ts
@@ -1,5 +1,4 @@
-import {
+export type {
   Scrapbox,
 } from "https://raw.githubusercontent.com/scrapbox-jp/types/0.0.5/mod.ts";
 export type { eventName } from "https://raw.githubusercontent.com/scrapbox-jp/types/0.0.5/mod.ts";
-export declare const scrapbox: Scrapbox;


### PR DESCRIPTION
ref [source map付きでapp.tsをbuildする (@takker/ScrapJupyter)](https://scrapbox.io/takker/source_map%E4%BB%98%E3%81%8D%E3%81%A7app.ts%E3%82%92build%E3%81%99%E3%82%8B_(@takker%2FScrapJupyter))