### PR TITLE
fix: esbuild-wasm-no-blobを誤ってバグ入りversionにdowngradeしていた

### DIFF
--- a/deps/esbuild-wasm.ts
+++ b/deps/esbuild-wasm.ts
@@ -1,5 +1,5 @@
 export {
   build,
   initialize,
-} from "https://raw.githubusercontent.com/takker99/esbuild-wasm-no-blob/0.19.2/mod.ts";
-export * from "https://raw.githubusercontent.com/takker99/esbuild-wasm-no-blob/0.19.2/types.ts";
+} from "https://raw.githubusercontent.com/takker99/esbuild-wasm-no-blob/0.20.1/mod.ts";
+export * from "https://raw.githubusercontent.com/takker99/esbuild-wasm-no-blob/0.20.1/types.ts";

--- a/deps/esbuild.ts
+++ b/deps/esbuild.ts
@@ -1,2 +1,2 @@
-// @deno-types=https://deno.land/x/esbuild@v0.12.1/mod.d.ts
+// @deno-types=https://deno.land/x/esbuild@v0.12.1/mod.d.ts#=
 export { build, stop } from "https://deno.land/x/esbuild@v0.12.1/mod.js#=";

--- a/deps/fs.ts
+++ b/deps/fs.ts
@@ -1,1 +1,1 @@
-export { ensureDir, exists } from "https://deno.land/std@0.218.2/fs/mod.ts";
+export { ensureDir, exists } from "https://deno.land/std@0.219.0/fs/mod.ts";

--- a/deps/path.ts
+++ b/deps/path.ts
@@ -1,2 +1,2 @@
-export * from "https://deno.land/std@0.218.2/path/mod.ts";
+export * from "https://deno.land/std@0.219.0/path/mod.ts";
 export { relative as relativeURL } from "https://raw.githubusercontent.com/takker99/scrapbox-bundler/0.1.0/path.ts";

--- a/deps/testing.ts
+++ b/deps/testing.ts
@@ -1,2 +1,2 @@
-export * from "https://deno.land/std@0.218.2/testing/asserts.ts";
-export * from "https://deno.land/std@0.218.2/testing/snapshot.ts";
+export * from "https://deno.land/std@0.219.0/assert/mod.ts";
+export * from "https://deno.land/std@0.219.0/testing/snapshot.ts";


### PR DESCRIPTION
ついでに、最新のesbuildに差し替えた