### PR TITLE
build: Update Deno Dependencies

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -1,12 +1,10 @@
-/// <reference lib="deno.ns"/>
-/// <reference lib="deno.unstable"/>
+/// <reference lib="dom.iterable"/>
 
 import { Command } from "https://deno.land/x/cliffy@v1.0.0-rc.3/command/mod.ts";
-import { build, stop } from "./deps/esbuild.ts";
+import { build, stop ,denoPlugins} from "./deps/esbuild.ts";
 import { fromFileUrl, relative } from "./deps/path.ts";
 import { exists } from "./deps/fs.ts";
 import { toTitleLc } from "./deps/scrapbox.ts";
-import { cache } from "https://deno.land/x/esbuild_plugin_cache@v0.2.10/mod.ts";
 
 const { options } = await new Command()
   .name("builder")
@@ -60,7 +58,7 @@ const { outputFiles } = await build({
     "WASM_URL": `"${wasmUrl}"`,
   },
   sourcemap: sourceMap ? "inline" : undefined,
-  plugins: [cache({ importmap: { imports: {} }, directory: "./cache" })],
+  plugins: [...denoPlugins()],
 });
 const mainSrc = outputFiles[0].text;
 

--- a/build.ts
+++ b/build.ts
@@ -1,7 +1,7 @@
 /// <reference lib="dom.iterable"/>
 
 import { Command } from "https://deno.land/x/cliffy@v1.0.0-rc.3/command/mod.ts";
-import { build, stop ,denoPlugins} from "./deps/esbuild.ts";
+import { build, denoPlugins, stop } from "./deps/esbuild.ts";
 import { fromFileUrl, relative } from "./deps/path.ts";
 import { exists } from "./deps/fs.ts";
 import { toTitleLc } from "./deps/scrapbox.ts";

--- a/deps/esbuild.ts
+++ b/deps/esbuild.ts
@@ -1,2 +1,2 @@
 export * from "https://deno.land/x/esbuild@v0.20.2/mod.js";
-export * from "https://deno.land/x/esbuild_deno_loader@0.9.0/mod.ts"
+export * from "https://deno.land/x/esbuild_deno_loader@0.9.0/mod.ts";

--- a/deps/esbuild.ts
+++ b/deps/esbuild.ts
@@ -1,2 +1,2 @@
-// @deno-types=https://deno.land/x/esbuild@v0.12.1/mod.d.ts#=
-export { build, stop } from "https://deno.land/x/esbuild@v0.12.1/mod.js#=";
+export * from "https://deno.land/x/esbuild@v0.20.2/mod.js";
+export * from "https://deno.land/x/esbuild_deno_loader@0.9.0/mod.ts"

--- a/deps/fs.ts
+++ b/deps/fs.ts
@@ -1,1 +1,1 @@
-export { ensureDir, exists } from "https://deno.land/std@0.219.0/fs/mod.ts";
+export { ensureDir, exists } from "https://deno.land/std@0.220.1/fs/mod.ts";

--- a/deps/path.ts
+++ b/deps/path.ts
@@ -1,2 +1,2 @@
-export * from "https://deno.land/std@0.219.0/path/mod.ts";
+export * from "https://deno.land/std@0.220.1/path/mod.ts";
 export { relative as relativeURL } from "https://raw.githubusercontent.com/takker99/scrapbox-bundler/0.1.0/path.ts";

--- a/deps/testing.ts
+++ b/deps/testing.ts
@@ -1,2 +1,2 @@
-export * from "https://deno.land/std@0.219.0/assert/mod.ts";
-export * from "https://deno.land/std@0.219.0/testing/snapshot.ts";
+export * from "https://deno.land/std@0.220.1/assert/mod.ts";
+export * from "https://deno.land/std@0.220.1/testing/snapshot.ts";


### PR DESCRIPTION
esbuildのversionを固定したらCIがコケたので、latest versionを使っても型エラーが出ないようにした