### PR TITLE
fix: Failed to detect extensions when filenames don't includes `.` at all.

### DIFF
--- a/extension.test.ts
+++ b/extension.test.ts
@@ -2,51 +2,51 @@ import { extensionToLoader, isAvailableExtensions } from "./extension.ts";
 import { assertEquals } from "./deps/testing.ts";
 
 Deno.test("isAvailableExtensions()", async (t) => {
-    await t.step(
-        "isAvailableExtensions should return true for valid extensions",
-        () => {
-            for (
-                const extension of [
-                    "ts",
-                    "js",
-                    "tsx",
-                    "jsx",
-                    "mjs",
-                    "javascript",
-                    "typescript",
-                ]
-            ) {
-                assertEquals(isAvailableExtensions(extension), true);
-            }
-        },
-    );
+  await t.step(
+    "isAvailableExtensions should return true for valid extensions",
+    () => {
+      for (
+        const extension of [
+          "ts",
+          "js",
+          "tsx",
+          "jsx",
+          "mjs",
+          "javascript",
+          "typescript",
+        ]
+      ) {
+        assertEquals(isAvailableExtensions(extension), true);
+      }
+    },
+  );
 });
 Deno.test("isAvailableExtensions()", async (t) => {
-    await t.step("should return 'js' for 'javascript'", () => {
-        assertEquals(extensionToLoader("javascript"), "js");
-    });
+  await t.step("should return 'js' for 'javascript'", () => {
+    assertEquals(extensionToLoader("javascript"), "js");
+  });
 
-    await t.step("should return 'js' for 'js'", () => {
-        assertEquals(extensionToLoader("js"), "js");
-    });
+  await t.step("should return 'js' for 'js'", () => {
+    assertEquals(extensionToLoader("js"), "js");
+  });
 
-    await t.step("should return 'js' for 'mjs'", () => {
-        assertEquals(extensionToLoader("mjs"), "js");
-    });
+  await t.step("should return 'js' for 'mjs'", () => {
+    assertEquals(extensionToLoader("mjs"), "js");
+  });
 
-    await t.step("should return 'ts' for 'typescript'", () => {
-        assertEquals(extensionToLoader("typescript"), "ts");
-    });
+  await t.step("should return 'ts' for 'typescript'", () => {
+    assertEquals(extensionToLoader("typescript"), "ts");
+  });
 
-    await t.step("should return 'ts' for 'ts'", () => {
-        assertEquals(extensionToLoader("ts"), "ts");
-    });
+  await t.step("should return 'ts' for 'ts'", () => {
+    assertEquals(extensionToLoader("ts"), "ts");
+  });
 
-    await t.step("should return 'jsx' for 'jsx'", () => {
-        assertEquals(extensionToLoader("jsx"), "jsx");
-    });
+  await t.step("should return 'jsx' for 'jsx'", () => {
+    assertEquals(extensionToLoader("jsx"), "jsx");
+  });
 
-    await t.step("should return 'tsx' for 'tsx'", () => {
-        assertEquals(extensionToLoader("tsx"), "tsx");
-    });
+  await t.step("should return 'tsx' for 'tsx'", () => {
+    assertEquals(extensionToLoader("tsx"), "tsx");
+  });
 });

--- a/extension.test.ts
+++ b/extension.test.ts
@@ -1,0 +1,52 @@
+import { extensionToLoader, isAvailableExtensions } from "./extension.ts";
+import { assertEquals } from "./deps/testing.ts";
+
+Deno.test("isAvailableExtensions()", async (t) => {
+    await t.step(
+        "isAvailableExtensions should return true for valid extensions",
+        () => {
+            for (
+                const extension of [
+                    "ts",
+                    "js",
+                    "tsx",
+                    "jsx",
+                    "mjs",
+                    "javascript",
+                    "typescript",
+                ]
+            ) {
+                assertEquals(isAvailableExtensions(extension), true);
+            }
+        },
+    );
+});
+Deno.test("isAvailableExtensions()", async (t) => {
+    await t.step("should return 'js' for 'javascript'", () => {
+        assertEquals(extensionToLoader("javascript"), "js");
+    });
+
+    await t.step("should return 'js' for 'js'", () => {
+        assertEquals(extensionToLoader("js"), "js");
+    });
+
+    await t.step("should return 'js' for 'mjs'", () => {
+        assertEquals(extensionToLoader("mjs"), "js");
+    });
+
+    await t.step("should return 'ts' for 'typescript'", () => {
+        assertEquals(extensionToLoader("typescript"), "ts");
+    });
+
+    await t.step("should return 'ts' for 'ts'", () => {
+        assertEquals(extensionToLoader("ts"), "ts");
+    });
+
+    await t.step("should return 'jsx' for 'jsx'", () => {
+        assertEquals(extensionToLoader("jsx"), "jsx");
+    });
+
+    await t.step("should return 'tsx' for 'tsx'", () => {
+        assertEquals(extensionToLoader("tsx"), "tsx");
+    });
+});

--- a/loader.test.ts
+++ b/loader.test.ts
@@ -2,91 +2,90 @@ import { assertEquals } from "./deps/testing.ts";
 import { responseToLoader } from "./loader.ts";
 
 Deno.test("responseToLoader", async (t) => {
-    await t.step(
-        "should return 'text' for a response with an unknown extension",
-        () => {
-            const response = new Response("Test response");
-            Object.defineProperty(response, "url", {
-                value: "https://example.com/file.txt",
-            });
-            assertEquals(responseToLoader(response), "text");
-        },
-    );
+  await t.step(
+    "should return 'text' for a response with an unknown extension",
+    () => {
+      const response = new Response("Test response");
+      Object.defineProperty(response, "url", {
+        value: "https://example.com/file.txt",
+      });
+      assertEquals(responseToLoader(response), "text");
+    },
+  );
 
-    await t.step(
-        "should return 'js' for a response with a valid extension",
-        () => {
-            const response = new Response("Test response", {
-                headers: { "Content-Type": "application/javascript" },
-            });
-            Object.defineProperty(response, "url", {
-                value: "https://example.com/script.js",
-            });
-            assertEquals(responseToLoader(response), "js");
-        },
-    );
+  await t.step(
+    "should return 'js' for a response with a valid extension",
+    () => {
+      const response = new Response("Test response", {
+        headers: { "Content-Type": "application/javascript" },
+      });
+      Object.defineProperty(response, "url", {
+        value: "https://example.com/script.js",
+      });
+      assertEquals(responseToLoader(response), "js");
+    },
+  );
 
-    await t.step(
-        "should return 'js' for a response with a valid extension",
-        () => {
-            const response = new Response("Test response", {
-                headers: { "Content-Type": "application/javascript" },
-            });
-            Object.defineProperty(response, "url", {
-                value: "https://example.com/index",
-            });
-            assertEquals(responseToLoader(response), "js");
-        },
-    );
+  await t.step(
+    "should return 'js' for a response with a valid extension",
+    () => {
+      const response = new Response("Test response", {
+        headers: { "Content-Type": "application/javascript" },
+      });
+      Object.defineProperty(response, "url", {
+        value: "https://example.com/index",
+      });
+      assertEquals(responseToLoader(response), "js");
+    },
+  );
 
-    await t.step(
-        "should return 'js' for a response with a valid extension",
-        () => {
-            const response = new Response("Test response",);
-            Object.defineProperty(response, "url", {
-                value: "https://example.com/js",
-            });
-            assertEquals(responseToLoader(response), "js");
-        },
-    );
+  await t.step(
+    "should return 'js' for a response with a valid extension",
+    () => {
+      const response = new Response("Test response");
+      Object.defineProperty(response, "url", {
+        value: "https://example.com/js",
+      });
+      assertEquals(responseToLoader(response), "js");
+    },
+  );
 
-    await t.step(
-        "should return 'js' for a response with an 'mjs' extension",
-        () => {
-            const response = new Response("Test response", {
-                headers: { "Content-Type": "text/plain" },
-            });
-            Object.defineProperty(response, "url", {
-                value: "https://example.com/script.mjs",
-            });
-            assertEquals(responseToLoader(response), "js");
-        },
-    );
+  await t.step(
+    "should return 'js' for a response with an 'mjs' extension",
+    () => {
+      const response = new Response("Test response", {
+        headers: { "Content-Type": "text/plain" },
+      });
+      Object.defineProperty(response, "url", {
+        value: "https://example.com/script.mjs",
+      });
+      assertEquals(responseToLoader(response), "js");
+    },
+  );
 
-    await t.step(
-        "should return the correct loader for a given response with a valid MIME type",
-        () => {
-            const response = new Response("Test response", {
-                headers: { "Content-Type": "text/css" },
-            });
-            Object.defineProperty(response, "url", {
-                value: "https://example.com/style.css",
-            });
-            assertEquals(responseToLoader(response), "css");
-        },
-    );
+  await t.step(
+    "should return the correct loader for a given response with a valid MIME type",
+    () => {
+      const response = new Response("Test response", {
+        headers: { "Content-Type": "text/css" },
+      });
+      Object.defineProperty(response, "url", {
+        value: "https://example.com/style.css",
+      });
+      assertEquals(responseToLoader(response), "css");
+    },
+  );
 
-    await t.step(
-        "should return 'text' for a response with an unknown MIME type",
-        () => {
-            const response = new Response("Test response", {
-                headers: { "Content-Type": "application/octet-stream" },
-            });
-            Object.defineProperty(response, "url", {
-                value: "https://example.com/file.bin",
-            });
-            assertEquals(responseToLoader(response), "text");
-        },
-    );
-
+  await t.step(
+    "should return 'text' for a response with an unknown MIME type",
+    () => {
+      const response = new Response("Test response", {
+        headers: { "Content-Type": "application/octet-stream" },
+      });
+      Object.defineProperty(response, "url", {
+        value: "https://example.com/file.bin",
+      });
+      assertEquals(responseToLoader(response), "text");
+    },
+  );
 });

--- a/loader.test.ts
+++ b/loader.test.ts
@@ -1,0 +1,92 @@
+import { assertEquals } from "./deps/testing.ts";
+import { responseToLoader } from "./loader.ts";
+
+Deno.test("responseToLoader", async (t) => {
+    await t.step(
+        "should return 'text' for a response with an unknown extension",
+        () => {
+            const response = new Response("Test response");
+            Object.defineProperty(response, "url", {
+                value: "https://example.com/file.txt",
+            });
+            assertEquals(responseToLoader(response), "text");
+        },
+    );
+
+    await t.step(
+        "should return 'js' for a response with a valid extension",
+        () => {
+            const response = new Response("Test response", {
+                headers: { "Content-Type": "application/javascript" },
+            });
+            Object.defineProperty(response, "url", {
+                value: "https://example.com/script.js",
+            });
+            assertEquals(responseToLoader(response), "js");
+        },
+    );
+
+    await t.step(
+        "should return 'js' for a response with a valid extension",
+        () => {
+            const response = new Response("Test response", {
+                headers: { "Content-Type": "application/javascript" },
+            });
+            Object.defineProperty(response, "url", {
+                value: "https://example.com/index",
+            });
+            assertEquals(responseToLoader(response), "js");
+        },
+    );
+
+    await t.step(
+        "should return 'js' for a response with a valid extension",
+        () => {
+            const response = new Response("Test response",);
+            Object.defineProperty(response, "url", {
+                value: "https://example.com/js",
+            });
+            assertEquals(responseToLoader(response), "js");
+        },
+    );
+
+    await t.step(
+        "should return 'js' for a response with an 'mjs' extension",
+        () => {
+            const response = new Response("Test response", {
+                headers: { "Content-Type": "text/plain" },
+            });
+            Object.defineProperty(response, "url", {
+                value: "https://example.com/script.mjs",
+            });
+            assertEquals(responseToLoader(response), "js");
+        },
+    );
+
+    await t.step(
+        "should return the correct loader for a given response with a valid MIME type",
+        () => {
+            const response = new Response("Test response", {
+                headers: { "Content-Type": "text/css" },
+            });
+            Object.defineProperty(response, "url", {
+                value: "https://example.com/style.css",
+            });
+            assertEquals(responseToLoader(response), "css");
+        },
+    );
+
+    await t.step(
+        "should return 'text' for a response with an unknown MIME type",
+        () => {
+            const response = new Response("Test response", {
+                headers: { "Content-Type": "application/octet-stream" },
+            });
+            Object.defineProperty(response, "url", {
+                value: "https://example.com/file.bin",
+            });
+            assertEquals(responseToLoader(response), "text");
+        },
+    );
+
+});

--- a/loader.ts
+++ b/loader.ts
@@ -1,4 +1,5 @@
 import { Loader } from "./deps/esbuild-wasm.ts";
+import { basename, extname } from "./deps/url.ts";
 
 const loaderList: Loader[] = [
   "base64",
@@ -22,8 +23,11 @@ const isLoader = (loader: string): loader is Loader =>
 
 export const responseToLoader = (response: Response): Loader => {
   const url = response.url;
-  const ext = url.split(".").pop();
-  if (ext && isLoader(ext)) return ext;
+  const filename = basename(url);
+  if (isLoader(filename)) return filename;
+  if (filename === "mjs") return "js";
+  const ext = extname(url).slice(1);
+  if (isLoader(ext)) return ext;
   if (ext === "mjs") return "js";
   const contentType = response.headers.get("Content-Type") ?? "text/plain";
   const mimeType = contentType.split(";")[0]?.trim?.() ?? "text/plain";


### PR DESCRIPTION
close [✅️️分割された無名コードブロック記法を結合して実行する (@takker/ScrapJupyter)](https://scrapbox.io/takker/✅️️分割された無名コードブロック記法を結合して実行する_(@takker%2FScrapJupyter))