### PR TITLE
fix: Use cache only when no url pattern is matched

### DIFF
--- a/remoteLoader.ts
+++ b/remoteLoader.ts
@@ -182,7 +182,7 @@ const load = async (
     ? true
     : reload === true
     ? false
-    : reload.some((pattern) => pattern.test(href));
+    : !reload.some((pattern) => pattern.test(href));
 
   const result = fetch(new Request(href), cacheFirst);
   progressCallback?.({


### PR DESCRIPTION
close [✅️@takker/ScrapJupyterでreloadが効いていなかった](https://scrapbox.io/takker/✅️@takker%2FScrapJupyterでreloadが効いていなかった)