### PR TITLE
feat: Support for multi-level sourcemap

### DIFF
--- a/__snapshots__/codeFile.test.ts.snap
+++ b/__snapshots__/codeFile.test.ts.snap
@@ -1,53 +1,10 @@
 export const snapshot = {};
 
 snapshot[`getCodeFiles() 1`] = `
-[
+[Map Iterator] {
   {
-    dir: "https://scrapbox.io/api/code/villagepump/%E3%83%AA%E3%83%B3%E3%82%AF%E3%82%92%E5%87%BA%E5%85%B8%E3%82%A2%E3%82%A4%E3%82%B3%E3%83%B3%E3%81%AB%E3%81%99%E3%82%8BUserCSS",
-    filename: "style.css",
     lang: "css",
-    lines: [
-      ".line .deco-\\\\. {",
-      "  font-size: .8em;",
-      "  position: relative;",
-      "  top: -0.5em;",
-      "}",
-      ".line:not(.cursor-line) .deco-\\\\. a:is(.page-link:not(.icon), .link) span:not(.empty-char-index) + span + span ~ span {",
-      "  display: inline-block;",
-      "  width: 0;",
-      "  text-indent: -9999px;",
-      "}",
-      ".line:not(.cursor-line) .deco-\\\\. .page-link:not(.icon) span.empty-char-index ~ span.char-index {",
-      "  display: inherit;",
-      "  width: inherit;",
-      "  text-indent: inherit;",
-      "}",
-      "",
-      ".line:not(.cursor-line) .deco-\\\\. a.page-link:not(.icon) span.empty-char-index + span::before {",
-      '  content: "#";',
-      "}",
-      "",
-      ".line .deco-\\\\. :is(.page-link:not(.icon), .link)::before {",
-      "  display: inline-block;",
-      "  min-width: 1.15em;",
-      "  padding-left: 1px;",
-      "  /* padding: 0 1px; */",
-      '  font-family: "Font Awesome 5 Free","Font Awesome 5 Brands";',
-      "  text-align: center;",
-      "  vertical-align: middle;",
-      "  font-weight: 900;",
-      '  content: "\\\\f02d";',
-      "}",
-      "",
-      "/* 斜体を取り消す */",
-      ".line .deco-\\\\..deco-\\\\/ {",
-      "  font-style: initial;",
-      "}",
-      ".line .deco-\\\\..deco-\\\\/ :is(.page-link:not(.icon), .link)::before {",
-      "  font-weight: 400;",
-      '  content: "\\\\f15c";',
-      "}",
-    ],
+    path: "https://scrapbox.io/api/code/villagepump/%E3%83%AA%E3%83%B3%E3%82%AF%E3%82%92%E5%87%BA%E5%85%B8%E3%82%A2%E3%82%A4%E3%82%B3%E3%83%B3%E3%81%AB%E3%81%99%E3%82%8BUserCSS/style.css",
     startIds: [
       "61596b221280f000007378f1",
       "6157ea821280f00000ad879f",
@@ -58,44 +15,25 @@ snapshot[`getCodeFiles() 1`] = `
     ],
   },
   {
-    dir: "https://scrapbox.io/api/code/villagepump/%E3%83%AA%E3%83%B3%E3%82%AF%E3%82%92%E5%87%BA%E5%85%B8%E3%82%A2%E3%82%A4%E3%82%B3%E3%83%B3%E3%81%AB%E3%81%99%E3%82%8BUserCSS",
-    filename: "style.css.disabled(css)",
-    lang: "disabled(css)",
-    lines: [
-      ".line:not(.cursor-line) .deco-\\\\.::before {",
-      '  content: "(";',
-      "}",
-      ".line:not(.cursor-line) .deco-\\\\.::after {",
-      '  content: ")";',
-      "}",
-    ],
+    lang: "css",
+    path: "https://scrapbox.io/api/code/villagepump/%E3%83%AA%E3%83%B3%E3%82%AF%E3%82%92%E5%87%BA%E5%85%B8%E3%82%A2%E3%82%A4%E3%82%B3%E3%83%B3%E3%81%AB%E3%81%99%E3%82%8BUserCSS/style.css.disabled",
     startIds: [
       "61596b3d1280f0000073793a",
     ],
   },
   {
-    dir: "https://scrapbox.io/api/code/villagepump/%E3%83%AA%E3%83%B3%E3%82%AF%E3%82%92%E5%87%BA%E5%85%B8%E3%82%A2%E3%82%A4%E3%82%B3%E3%83%B3%E3%81%AB%E3%81%99%E3%82%8BUserCSS",
-    filename: "差分.diff",
     lang: "diff",
-    lines: [
-      "+ .line:not(.cursor-line) .deco-\\\\. a:is(.page-link:not(.icon), .link) span:not(.empty-char-index) + span + span ~ span {",
-      "- .line:not(.cursor-line) .deco-\\\\. a:is(.page-link:not(.icon), .link) span {",
-    ],
+    path: "https://scrapbox.io/api/code/villagepump/%E3%83%AA%E3%83%B3%E3%82%AF%E3%82%92%E5%87%BA%E5%85%B8%E3%82%A2%E3%82%A4%E3%82%B3%E3%83%B3%E3%81%AB%E3%81%99%E3%82%8BUserCSS/%E5%B7%AE%E5%88%86.diff",
     startIds: [
       "61fe4a9b1280f00000a67cbd",
     ],
   },
   {
-    dir: "https://scrapbox.io/api/code/villagepump/%E3%83%AA%E3%83%B3%E3%82%AF%E3%82%92%E5%87%BA%E5%85%B8%E3%82%A2%E3%82%A4%E3%82%B3%E3%83%B3%E3%81%AB%E3%81%99%E3%82%8BUserCSS",
-    filename: "差分2.diff",
     lang: "diff",
-    lines: [
-      "+ .line:not(.cursor-line) .deco-\\\\. .page-link:not(.icon) span.empty-char-index ~ span.char-index {",
-      "- .line:not(.cursor-line) .deco-\\\\. a.page-link:not(.icon) span.empty-char-index ~ span {",
-    ],
+    path: "https://scrapbox.io/api/code/villagepump/%E3%83%AA%E3%83%B3%E3%82%AF%E3%82%92%E5%87%BA%E5%85%B8%E3%82%A2%E3%82%A4%E3%82%B3%E3%83%B3%E3%81%AB%E3%81%99%E3%82%8BUserCSS/%E5%B7%AE%E5%88%862.diff",
     startIds: [
       "61fe4af31280f00000a67cd2",
     ],
   },
-]
+}
 `;

--- a/app.ts
+++ b/app.ts
@@ -3,12 +3,11 @@
 /// <reference lib="dom"/>
 /// <reference lib="dom.iterable"/>
 import { getCodeFiles } from "./codeFile.ts";
-import { load } from "./bundler.ts";
+import { load } from "./bundle.ts";
 import { isAvailableExtensions } from "./extension.ts";
 import { eventName, Scrapbox, takeInternalLines } from "./deps/scrapbox.ts";
 import { execMenu } from "./components/execMenu.ts";
 import { throttle } from "./deps/throttle.ts";
-import { viewGraph } from "./viewGraph.ts";
 declare const scrapbox: Scrapbox;
 
 /** ScrapJupyterを起動する
@@ -20,52 +19,45 @@ declare const scrapbox: Scrapbox;
 export const setup = async (
   wasm: WebAssembly.Module,
   workerURL: string | URL,
-) => {
+): Promise<() => void> => {
   const bundle = await load(wasm, workerURL);
   const menus = [] as ReturnType<typeof execMenu>[];
 
   const update = async () => {
-    const files = getCodeFiles(
-      scrapbox.Project.name,
-      scrapbox.Page.title ?? "",
-      takeInternalLines(),
-    );
     // ボタンを全部リセットする
     menus.forEach(({ menu, setStatus }) => {
       setStatus("none");
       menu.remove();
     });
-    files.forEach((file) => {
+    const files = getCodeFiles(
+      scrapbox.Project.name,
+      scrapbox.Page.title ?? "",
+      takeInternalLines(),
+    );
+    for (const file of files) {
       const extension = file.lang.toLowerCase();
       // TS/JS以外は無視
-      if (!isAvailableExtensions(extension)) return;
-      file.startIds.forEach((id) => {
+      if (!isAvailableExtensions(extension)) continue;
+      for (const id of file.startIds) {
         const line = document.getElementById(`L${id}`);
         const { menu, setStatus } = execMenu(
           async () => {
             await setStatus("loading");
             try {
-              const { contents, graph } = await bundle(
-                file.lines.join("\n"),
-                {
-                  extension,
-                  fileName: file.filename,
-                  dirURL: `${file.dir}/`,
-                },
-              );
-              console.debug(viewGraph(graph, true));
+              const { contents } = await bundle(file.path);
               console.debug("execute:", contents);
               await Function(`return (async()=>{${contents}})()`)();
               await setStatus("pass");
             } catch (e) {
+              console.error(e);
               await setStatus("fail", e.toString());
             }
           },
         );
         menus.push({ menu, setStatus });
         line?.insertBefore?.(menu, line?.firstElementChild);
-      });
-    });
+      }
+    }
     await Promise.resolve();
   };
   const callback = throttle(update, {

--- a/codeFile.test.ts
+++ b/codeFile.test.ts
@@ -1,3 +1,5 @@
+/// <reference lib="deno.ns" />
+
 import { getCodeFiles } from "./codeFile.ts";
 import { assertSnapshot } from "./deps/testing.ts";
 import json from "./sample-page.json" with { type: "json" };

--- a/codeTitle.test.ts
+++ b/codeTitle.test.ts
@@ -1,0 +1,51 @@
+import { assertEquals } from "./deps/testing.ts";
+import { parseCodeTitle, ParseCodeTitleResult } from "./codeTitle.ts";
+
+Deno.test("parseCodeTitle()", async (t) => {
+  await t.step(
+    "should return the correct result when given a title with parentheses",
+    () => {
+      const title = "example.ts(TypeScript)";
+      const expected: ParseCodeTitleResult = {
+        fileName: "example.ts",
+        lang: "TypeScript",
+      };
+      assertEquals(parseCodeTitle(title), expected);
+      assertEquals(parseCodeTitle("sample.tikz(tex)"), {
+        fileName: "sample.tikz",
+        lang: "tex",
+      });
+      assertEquals(parseCodeTitle("sample(tex)"), {
+        fileName: "sample",
+        lang: "tex",
+      });
+    },
+  );
+
+  await t.step(
+    "should return the correct result when given a title without parentheses",
+    () => {
+      const title = "example.js";
+      const expected: ParseCodeTitleResult = {
+        fileName: "example.js",
+        lang: "js",
+      };
+      assertEquals(parseCodeTitle(title), expected);
+      assertEquals(parseCodeTitle("example.min.js"), {
+        fileName: "example.min.js",
+        lang: "js",
+      });
+    },
+  );
+  await t.step(
+    "should return the correct result when given a title without an extension",
+    () => {
+      const title = "example";
+      const expected: ParseCodeTitleResult = {
+        fileName: "example",
+        lang: "example",
+      };
+      assertEquals(parseCodeTitle(title), expected);
+    },
+  );
+});

--- a/codeTitle.ts
+++ b/codeTitle.ts
@@ -1,0 +1,14 @@
+export interface ParseCodeTitleResult {
+  fileName: string;
+  lang: string;
+}
+export const parseCodeTitle = (title: string): ParseCodeTitleResult => {
+  {
+    const match = title.match(/^([^(]+)\(([^)]+)\)$/);
+    if (match) return { fileName: match[1], lang: match[2] };
+  }
+  const lang = title.split(".").pop();
+  return lang === undefined
+    ? { fileName: title, lang: title }
+    : { fileName: title, lang };
+};

--- a/deps/deno-mock.js
+++ b/deps/deno-mock.js
@@ -1,0 +1,11 @@
+// @ts-nocheck - Deno types are not available in the browser
+
+if (!self.Deno) {
+  self.Deno = {
+    build: { os: "linux" },
+    errors: { AlreadyExists: Error },
+    env: { get: () => undefined },
+    permissions: { query: () => Promise.resolve("denied") },
+    cwd: () => location.href,
+  };
+}

--- a/deps/esbuild.ts
+++ b/deps/esbuild.ts
@@ -1,2 +1,0 @@
-export * from "https://deno.land/x/esbuild@v0.23.0/mod.js";
-export * from "https://deno.land/x/esbuild_deno_loader@0.9.0/mod.ts";

--- a/deps/esbuild_deno_loader.ts
+++ b/deps/esbuild_deno_loader.ts
@@ -1,0 +1,27 @@
+import "./deno-mock.js";
+import { Plugin } from "./esbuild-wasm.ts";
+import { denoResolverPlugin } from "https://deno.land/x/esbuild_deno_loader@0.9.0/mod.ts";
+
+// ported from https://deno.land/x/esbuild_deno_loader@0.9.0/src/plugin_deno_resolver.ts
+export interface DenoResolverPluginOptions {
+  /**
+   * Specify the path to a deno.json config file to use. This is equivalent to
+   * the `--config` flag to the Deno executable. This path must be absolute.
+   */
+  configPath?: string;
+  /**
+   * Specify a URL to an import map file to use when resolving import
+   * specifiers. This is equivalent to the `--import-map` flag to the Deno
+   * executable. This URL may be remote or a local file URL.
+   *
+   * If this option is not specified, the deno.json config file is consulted to
+   * determine what import map to use, if any.
+   */
+  importMapURL?: string;
+}
+
+/**  {@link denoResolverPlugin} for browser */
+export const resolver: (options?: DenoResolverPluginOptions) => Plugin =
+  denoResolverPlugin as unknown as (
+    options?: DenoResolverPluginOptions,
+  ) => Plugin;

--- a/deps/fs.ts
+++ b/deps/fs.ts
@@ -1,1 +1,0 @@
-export { ensureDir, exists } from "https://deno.land/std@0.224.0/fs/mod.ts";

--- a/deps/importmap.ts
+++ b/deps/importmap.ts
@@ -1,5 +1,0 @@
-export {
-  resolveImportMap,
-  resolveModuleSpecifier,
-} from "https://deno.land/x/importmap@0.2.1/mod.ts";
-export type { ImportMap } from "https://deno.land/x/importmap@0.2.1/mod.ts";

--- a/deps/media_types.ts
+++ b/deps/media_types.ts
@@ -1,1 +1,0 @@
-export { extension } from "https://deno.land/x/media_types@deprecated/mod.ts";

--- a/deps/option-t.ts
+++ b/deps/option-t.ts
@@ -1,0 +1,2 @@
+export * from "https://esm.sh/option-t@49.1.0/plain_result";
+export * from "https://esm.sh/option-t@49.1.0/maybe";

--- a/extension.test.ts
+++ b/extension.test.ts
@@ -1,3 +1,4 @@
+/// <reference lib="deno.ns" />
 import { extensionToLoader, isAvailableExtensions } from "./extension.ts";
 import { assertEquals } from "./deps/testing.ts";
 

--- a/extractSourceMapURL.test.ts
+++ b/extractSourceMapURL.test.ts
@@ -1,0 +1,100 @@
+import { expectErr, expectOk } from "./deps/option-t.ts";
+import { assertEquals } from "./deps/testing.ts";
+import { extractSourceMapURL } from "./extractSourceMapURL.ts";
+
+Deno.test("extractSourceMapURL()", async (t) => {
+  const base = "https://example.com";
+  await t.step("in single-line comment", () => {
+    const code = `
+    // Some code
+    //# sourceMappingURL=example.map
+  `;
+    assertEquals(
+      expectOk(extractSourceMapURL(code, base), "Source map URL not found"),
+      { url: new URL("example.map", base), start: 43, end: 54 },
+    );
+  });
+
+  await t.step("in /* comment", () => {
+    const code = `
+      Some code
+      /*# sourceMappingURL=example.map */
+  `;
+    assertEquals(
+      expectOk(extractSourceMapURL(code, base), "Source map URL not found"),
+      { url: new URL("example.map", base), start: 44, end: 55 },
+    );
+  });
+
+  await t.step("in unclosed multi-line comment", () => {
+    const code = `
+    /*
+      Some code
+      //# sourceMappingURL=example.map
+  `;
+    assertEquals(
+      expectOk(extractSourceMapURL(code, base), "Source map URL not found"),
+      { url: new URL("example.map", base), start: 51, end: 62 },
+    );
+  });
+
+  await t.step("as trailing whitespace", () => {
+    const code = `
+    // Some code
+    //# sourceMappingURL=example.map
+  `;
+    assertEquals(
+      expectOk(extractSourceMapURL(code, base), "Source map URL not found"),
+      { url: new URL("example.map", base), start: 43, end: 54 },
+    );
+  });
+
+  await t.step("as code character", () => {
+    const code = `
+    // Some code
+    //# sourceMappingURL=example.map
+    const url = "https://example.com";
+  `;
+    assertEquals(
+      expectOk(extractSourceMapURL(code, base), "Source map URL not found"),
+      { url: new URL("example.map", base), start: 43, end: 54 },
+    );
+  });
+
+  await t.step("not found", () => {
+    assertEquals(
+      expectErr(
+        extractSourceMapURL(
+          `
+    // Some code
+    const url = "https://example.com";
+  `,
+          base,
+        ),
+        "Source map URL found",
+      ),
+      {
+        name: "NotFoundError",
+        message: "Source map URL is not found",
+      },
+    );
+  });
+
+  assertEquals(
+    expectErr(
+      extractSourceMapURL(
+        `
+    // Some code
+    const url = "https://example.com";
+    /*# sourceMappingURL=example.map
+  `,
+        base,
+      ),
+      "Source map URL found",
+    ),
+    {
+      name: "NotFoundError",
+      message: "Source map URL is not found",
+    },
+  );
+});

--- a/extractSourceMapURL.ts
+++ b/extractSourceMapURL.ts
@@ -1,0 +1,72 @@
+import {
+  createErr,
+  createOk,
+  isErr,
+  okOrElseForMaybe,
+  Result,
+  unwrapOk,
+} from "./deps/option-t.ts";
+
+export interface InvalidURLError {
+  name: "InvalidURLError";
+  message: string;
+}
+export interface NotFoundError {
+  name: "NotFoundError";
+  message: string;
+}
+/**
+ * Extracts the source map URL from the given code.
+ *
+ * This code is based on https://github.com/evanw/source-map-visualization/blob/f3e9dfec20e7bfd9625d03dd0d427affa74a9c43/code.js#L103-L145 under @evanw 's license.
+ *
+ * @param code - The code from which to extract the source map URL.
+ * @param _lang - The language of the code (currently only supports `"js"`).
+ * @returns The extracted source map URL as a `URL` object, or `null` if no source map URL is found.
+ */
+export const extractSourceMapURL = (
+  code: string,
+  base: string | URL | undefined,
+): Result<
+  { url: URL; start: number; end: number },
+  InvalidURLError | NotFoundError
+> => {
+  const result = okOrElseForMaybe(
+    extract(code),
+    () => ({
+      name: "NotFoundError",
+      message: "Source map URL is not found",
+    } as NotFoundError),
+  );
+  if (isErr(result)) return result;
+  const { url, start, end } = unwrapOk(result);
+  return URL.canParse(url, base)
+    ? createOk({ url: new URL(url, base), start, end })
+    : createErr({
+      name: "InvalidURLError",
+      message: `Invalid URL: ${url}`,
+    });
+};
+
+const extract = (code: string) => {
+  // Check for both "//" and "/*" comments. This is mostly done manually
+  // instead of doing it all with a regular expression because Firefox's
+  // regular expression engine crashes with an internal error when the
+  // match is too big.
+  for (const match of code.matchAll(/\/([*/])[#@] *sourceMappingURL=/g)) {
+    const start = match.index + match[0].length;
+    const n = code.length;
+    let end = start;
+    while (end < n && code.charCodeAt(end) > 32) {
+      end++;
+    }
+    if (end === start) continue;
+    if (match[1] === "/" || code.indexOf("*/", end) > 0) {
+      return {
+        url: code.slice(start, end),
+        start,
+        end,
+      };
+    }
+  }
+};

--- a/loader.test.ts
+++ b/loader.test.ts
@@ -1,3 +1,5 @@
+/// <reference lib="deno.ns" />
+
 import { assertEquals } from "./deps/testing.ts";
 import { responseToLoader } from "./loader.ts";
 

--- a/remoteLoader.ts
+++ b/remoteLoader.ts
@@ -6,16 +6,42 @@ import {
   OnResolveResult,
   Plugin,
 } from "./deps/esbuild-wasm.ts";
+import { isErr, isOk, Result, unwrapErr, unwrapOk } from "./deps/option-t.ts";
 import { esbuildResolutionToURL } from "./esbuildResolution.ts";
+import { extractSourceMapURL } from "./extractSourceMapURL.ts";
 import { responseToLoader } from "./loader.ts";
+import { toDataURL } from "./toDataURL.ts";
 
 export interface RemoteLoaderInit {
   importMapURL?: URL;
   reload?: boolean | URLPattern[];
-  fetch: (req: Request, cacheFirst: boolean) => Promise<[Response, boolean]>;
+  fetch: RobustFetch;
 
   onProgress?: (message: LoadEvent) => void;
 }
+
+export interface NetworkError {
+  name: "NetworkError";
+  message: string;
+  request: Request;
+}
+export interface AbortError {
+  name: "AbortError";
+  message: string;
+  request: Request;
+}
+export interface HTTPError {
+  name: "HTTPError";
+  message: string;
+  response: Response;
+}
+
+export type RobustFetch = (
+  req: Request,
+  cacheFirst: boolean,
+) => Promise<
+  Result<[Response, boolean], NetworkError | AbortError | HTTPError>
+>;
 
 export interface LoadEvent {
   path: string;
@@ -30,7 +56,7 @@ export const remoteLoader = (
       path: args.path,
       namespace: args.namespace,
     });
-    for (const protocol of supportedProtocols) {
+    for (const protocol of [...supportedProtocols, ...notSupportedProtocols]) {
       onResolve(
         { filter: /.*/, namespace: protocol.slice(0, -1) },
         handleResolve,
@@ -48,21 +74,20 @@ export const remoteLoader = (
     for (const protocol of supportedProtocols) {
       onLoad({ filter: /.*/, namespace: protocol.slice(0, -1) }, handleLoad);
     }
+    for (const protocol of notSupportedProtocols) {
+      onLoad({ filter: /.*/, namespace: protocol.slice(0, -1) }, () => {
+        throw new Error(`${protocol} import is not supported yet.`);
+      });
+    }
   },
 });
 
-const supportedProtocols = [
-  "http:",
-  "https:",
-  "data:",
-  "npm:",
-  "jsr:",
-  "node:",
-] as const;
+const supportedProtocols = ["http:", "https:", "data:"] as const;
+const notSupportedProtocols = ["npm:", "jsr:", "node:"] as const;
 
 const load = async (
   href: string,
-  fetch: (req: Request, cacheFirst: boolean) => Promise<[Response, boolean]>,
+  fetch: RobustFetch,
   reload?: boolean | URLPattern[],
   onProgress?: (message: LoadEvent) => void,
 ): Promise<OnLoadResult> => {
@@ -72,21 +97,52 @@ const load = async (
     ? false
     : !reload.some((pattern) => pattern.test(href));
 
-  const result = fetch(new Request(href), cacheFirst).then(
-    async ([res, isCache]) => {
-      const loader = responseToLoader(res);
-      const blob = await res.blob();
-      return [blob, loader, isCache] as const;
-    },
-  );
+  const result = await fetch(new Request(href), cacheFirst);
+  if (isErr(result)) {
+    return { errors: [{ text: unwrapErr(result).message }] };
+  }
+  const [res, isCache] = unwrapOk(result);
+  const loader = responseToLoader(res);
   onProgress?.({
     path: href,
-    done: result.then(([blob, loader, isCache]) => ({
+    done: res.clone().blob().then((blob) => ({
       size: blob.size,
       loader,
       isCache,
     })),
   });
-  const [blob, loader] = await result;
+  const blob = await res.blob();
+  {
+    const contents = await blob.text();
+    const result = extractSourceMapURL(contents, new URL(href));
+    if (isOk(result)) {
+      const { url, start, end } = unwrapOk(result);
+      if (url.protocol !== "data:") {
+        const res = await fetch(new Request(url), cacheFirst);
+        if (isErr(res)) {
+          return {
+            contents: new Uint8Array(await blob.arrayBuffer()),
+            loader,
+            warnings: [{
+              text: `[${
+                unwrapErr(res).message
+              }] Failed to fetch the source map URL`,
+              notes: [{
+                text: `Source map URL: ${url}`,
+              }, {
+                text: `Original URL: ${href}`,
+              }],
+              detail: unwrapErr(res),
+            }],
+          };
+        }
+        const dataURL = await unwrapOk(res)[0].blob().then(toDataURL);
+        const replaced = contents.slice(0, start) + dataURL +
+          contents.slice(end);
+        return { contents: replaced, loader };
+      }
+    }
+  }
+
   return { contents: new Uint8Array(await blob.arrayBuffer()), loader };
 };

--- a/remoteLoader.ts
+++ b/remoteLoader.ts
@@ -2,207 +2,84 @@ import {
   Loader,
   OnLoadArgs,
   OnLoadResult,
+  OnResolveArgs,
+  OnResolveResult,
   Plugin,
 } from "./deps/esbuild-wasm.ts";
-import {
-  ImportMap,
-  resolveImportMap,
-  resolveModuleSpecifier,
-} from "./deps/importmap.ts";
-import { toFileUrl } from "./deps/path.ts";
-import { escape } from "./deps/regexp.ts";
-import { basename, extname } from "./deps/url.ts";
-import {
-  esbuildResolutionToURL,
-  urlToEsbuildResolution,
-} from "./esbuildResolution.ts";
-import { extensionToLoader, isAvailableExtensions } from "./extension.ts";
+import { esbuildResolutionToURL } from "./esbuildResolution.ts";
 import { responseToLoader } from "./loader.ts";
 
 export interface RemoteLoaderInit {
   importMapURL?: URL;
   reload?: boolean | URLPattern[];
-  sources?: Source[];
   fetch: (req: Request, cacheFirst: boolean) => Promise<[Response, boolean]>;
 
-  progressCallback?: (message: ResolveInfo | LoadInfo) => void;
+  onProgress?: (message: LoadEvent) => void;
 }
 
-export interface Source {
-  path: string;
-  contents: string;
-  loader?: Loader;
-}
-
-export interface ResolveInfo {
-  type: "resolve";
-  external: boolean;
-  path: string;
-  parent?: string;
-}
-
-export interface LoadInfo {
-  type: "load";
+export interface LoadEvent {
   path: string;
   done: Promise<{ size: number; loader: Loader; isCache: boolean }>;
 }
-
 export const remoteLoader = (
   options: RemoteLoaderInit,
 ): Plugin => ({
-  name: "remote-resource",
-  setup({ onStart, onResolve, onLoad, initialOptions }) {
-    const {
-      importMapURL,
-      sources = [],
-      progressCallback,
-    } = options ?? {};
-
-    let importMap: ImportMap = {};
-
-    onStart(async () => {
-      if (!importMapURL) return;
-      const importMapSource = await load(
-        `${importMapURL}`,
-        options.fetch,
-        sources,
-        options.reload,
-        progressCallback,
-      );
-      importMap = resolveImportMap(
-        JSON.parse(
-          importMapSource.contents instanceof Uint8Array
-            ? new TextDecoder().decode(importMapSource.contents)
-            : importMapSource.contents ?? "",
-        ),
-        importMapURL,
-      );
+  name: "remote-loader",
+  setup({ onLoad, onResolve }) {
+    const handleResolve = (args: OnResolveArgs): OnResolveResult => ({
+      path: args.path,
+      namespace: args.namespace,
     });
-
-    const externalRegexps = (initialOptions.external ?? []).map((path) =>
-      new RegExp(escape(path).replace(/\\\*/g, ".*"))
-    );
-
-    onResolve(
-      { filter: /.*/ },
-      (args) => {
-        // This code is based on https://github.com/lucacasonato/esbuild_deno_loader/blob/0.10.3/src/plugin_deno_resolver.ts
-
-        // The first pass resolver performs synchronous resolution. This
-        // includes relative to absolute specifier resolution and import map
-        // resolution.
-
-        // We have to first determine the referrer URL to use when resolving
-        // the specifier. This is either the importer URL, or the resolveDir
-        // URL if the importer is not specified (ie if the specifier is at the
-        // root).
-        let referrer: URL;
-        if (args.importer !== "") {
-          if (args.namespace === "") {
-            throw new Error("[assert] namespace is empty");
-          }
-          referrer = new URL(`${args.namespace}:${args.importer}`);
-        } else if (args.resolveDir !== "") {
-          referrer = new URL(`${toFileUrl(args.resolveDir).href}/`);
-        } else {
-          return undefined;
-        }
-
-        // We can then resolve the specifier relative to the referrer URL. If
-        // an import map is specified, we use that to resolve the specifier.
-        let resolved: URL;
-        if (importMap !== null) {
-          const res = resolveModuleSpecifier(
-            args.path,
-            importMap,
-            new URL(referrer),
-          );
-          resolved = new URL(res);
-        } else {
-          resolved = new URL(args.path, referrer);
-        }
-
-        const info: ResolveInfo = {
-          type: "resolve",
-          external: false,
-          path: resolved.href,
-        };
-        if (args.kind !== "entry-point") info.parent = referrer.href;
-
-        for (const externalRegexp of externalRegexps) {
-          if (externalRegexp.test(resolved.href)) {
-            info.external = true;
-            progressCallback?.(info);
-            return { path: info.path, external: info.external };
-          }
-        }
-        progressCallback?.(info);
-
-        // Now pass the resolved specifier back into the resolver, for a second
-        // pass. Now plugins can perform any resolution they want on the fully
-        // resolved specifier.
-        return urlToEsbuildResolution(resolved);
-        // res.then(console.log);
-      },
-    );
-
-    const loader = (
+    for (const protocol of supportedProtocols) {
+      onResolve(
+        { filter: /.*/, namespace: protocol.slice(0, -1) },
+        handleResolve,
+      );
+    }
+    const handleLoad = (
       args: OnLoadArgs,
     ): Promise<OnLoadResult | undefined> =>
       load(
         esbuildResolutionToURL(args).href,
         options.fetch,
-        sources,
         options.reload,
-        progressCallback,
+        options.onProgress,
       );
-
-    onLoad({ filter: /.*/, namespace: "file" }, loader);
-    onLoad({ filter: /.*/, namespace: "http" }, loader);
-    onLoad({ filter: /.*/, namespace: "https" }, loader);
-    onLoad({ filter: /.*/, namespace: "data" }, loader);
+    for (const protocol of supportedProtocols) {
+      onLoad({ filter: /.*/, namespace: protocol.slice(0, -1) }, handleLoad);
+    }
   },
 });
+
+const supportedProtocols = [
+  "http:",
+  "https:",
+  "data:",
+  "npm:",
+  "jsr:",
+  "node:",
+] as const;
 
 const load = async (
   href: string,
   fetch: (req: Request, cacheFirst: boolean) => Promise<[Response, boolean]>,
-  sources: Source[],
   reload?: boolean | URLPattern[],
-  progressCallback?: (message: ResolveInfo | LoadInfo) => void,
+  onProgress?: (message: LoadEvent) => void,
 ): Promise<OnLoadResult> => {
-  const source = sources.find((source) => source.path === href);
-
-  if (source !== undefined) {
-    const extension = extname(href).slice(1) || basename(href);
-
-    const loader = source.loader ??
-      (isAvailableExtensions(extension)
-        ? extensionToLoader(extension)
-        : "text");
-    progressCallback?.({
-      type: "load",
-      path: href,
-      done: Promise.resolve({
-        size: new Blob([source.contents]).size,
-        loader,
-        isCache: true,
-      }),
-    });
-    return { contents: source.contents, loader };
-  }
   const cacheFirst = !reload
     ? true
     : reload === true
     ? false
     : !reload.some((pattern) => pattern.test(href));
 
-  const result = fetch(new Request(href), cacheFirst).then(([res, isCache]) => {
-    const loader = responseToLoader(res);
-    return res.blob().then((blob) => [blob, loader, isCache] as const);
-  });
-  progressCallback?.({
-    type: "load",
+  const result = fetch(new Request(href), cacheFirst).then(
+    async ([res, isCache]) => {
+      const loader = responseToLoader(res);
+      const blob = await res.blob();
+      return [blob, loader, isCache] as const;
+    },
+  );
+  onProgress?.({
     path: href,
     done: result.then(([blob, loader, isCache]) => ({
       size: blob.size,

--- a/toDataURL.test.ts
+++ b/toDataURL.test.ts
@@ -1,0 +1,13 @@
+import { assertEquals } from "./deps/testing.ts";
+import { toDataURL } from "./toDataURL.ts";
+
+Deno.test("toDataURL()", async (t) => {
+  await t.step(
+    "should resolve with a data URL when given a valid Blob",
+    async () => {
+      const blob = new Blob(["Test data"], { type: "text/plain" });
+      const result = await toDataURL(blob);
+      assertEquals(result, "data:text/plain;base64,VGVzdCBkYXRh");
+    },
+  );
+});

--- a/toDataURL.ts
+++ b/toDataURL.ts
@@ -1,0 +1,18 @@
+/**
+ * Converts a Blob object to a data URL string.
+ *
+ * @param data - The Blob object to convert.
+ * @returns A Promise that resolves with the data URL string.
+ */
+export const toDataURL = (data: Blob): Promise<string> =>
+  new Promise(
+    (resolve, reject) => {
+      const reader = new FileReader();
+      reader.addEventListener(
+        "load",
+        () => resolve(reader.result as string),
+      );
+      reader.addEventListener("error", () => reject(reader.error));
+      reader.readAsDataURL(data);
+    },
+  );


### PR DESCRIPTION
- URL解決を`esbuild_deno_loader`に委託
- コードブロックの中身を保持せず、全てURL経由でbuildする
- Dependency Graphのコンソール出力を一旦削除
- 対応していないprotocolに対して、その旨を書いたエラーを出すようにした
- fetchの例外をResult typeで取り出すようにした