### PR TITLE
fix: Detect semver whose special characters are percent-encoded

### DIFF
--- a/esbuildResolution.ts
+++ b/esbuildResolution.ts
@@ -38,7 +38,6 @@ export const urlToEsbuildResolution = (url: URL): EsbuildResolution => {
  * representing a file.
  */
 export const esbuildResolutionToURL = (specifier: EsbuildResolution): URL => {
-  specifier.path = decodeURIComponent(specifier.path);
   if (specifier.namespace === "file") {
     return toFileUrl(specifier.path);
   }

--- a/specifiers.test.ts
+++ b/specifiers.test.ts
@@ -104,6 +104,18 @@ const NPM_SPECIFIER: NpmSpecifierTestCase[] = [
     }),
   },
   {
+    specifier: "npm:test@%5E1.2",
+    ...createOk({
+      name: "test",
+      range: [[
+        { major: 1, minor: 2, operator: ">=", patch: 0 },
+        { major: 2, minor: 0, operator: "<", patch: 0 },
+      ]],
+      tag: "^1.2",
+      entryPoint: ".",
+    }),
+  },
+  {
     specifier: "npm:test@~1.1/sub_path",
     ...createOk({
       name: "test",
@@ -223,6 +235,19 @@ const JSR_SPECIFIER_VALID: JsrSpecifierTestCase[] = [
       ]],
       tag: "~1.1",
       entryPoint: "./sub_path",
+    }),
+  },
+
+  {
+    specifier: "jsr:@scope/test@%5E1.2",
+    ...createOk({
+      name: "@scope/test",
+      range: [[
+        { major: 1, minor: 2, operator: ">=", patch: 0 },
+        { major: 2, minor: 0, operator: "<", patch: 0 },
+      ]],
+      tag: "^1.2",
+      entryPoint: ".",
     }),
   },
   {

--- a/specifiers.ts
+++ b/specifiers.ts
@@ -69,7 +69,9 @@ export const parseNpmSpecifier = (
   }
 
   const name = path.slice(startIndex, versionStartIndex);
-  const tag = path.slice(versionStartIndex + 1, pathStartIndex);
+  const tag = decodeURIComponent(
+    path.slice(versionStartIndex + 1, pathStartIndex),
+  );
   const range = tag ? tryParseRange(tag) ?? [[ALL]] : [[ALL]];
   const rawEntryPoint = path.slice(pathStartIndex + 1);
   const entryPoint = rawEntryPoint
@@ -115,7 +117,9 @@ export const parseJsrSpecifier = (
 
   versionStartIndex = Math.min(versionStartIndex, pathStartIndex);
   const name = path.slice(startIndex, versionStartIndex);
-  const tag = path.slice(versionStartIndex + 1, pathStartIndex);
+  const tag = decodeURIComponent(
+    path.slice(versionStartIndex + 1, pathStartIndex),
+  );
   const range = tag ? tryParseRange(tag) ?? [[ALL]] : [[ALL]];
   const rawEntryPoint = path.slice(pathStartIndex + 1);
   const entryPoint = rawEntryPoint


### PR DESCRIPTION
fix #61 
ここでpercent encodingsをdecodeしてしまうと、`"../takker99%2Fscrapbox-incremental-fulltext-search/mod.tsx"`のような、percent encodingされたままでないと読み込めないpathまでdecodeされてしまう。

問題だったのは、`jsr:@core/unknownutil@^1.0.4`の`^`のような特殊文字が`URL`内でencodeされることだったので、semverを処理する際にdecodeすることにする。